### PR TITLE
feat: added endpoint and force_path_style config for the aws remote

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bacup"
-version = "0.1.12"
+version = "0.1.13"
 description = "An easy-to-use backup tool designed for servers."
 readme = "README.md"
 authors = ["Paolo Galeone <me@pgaleone.eu>"]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Configuring the remotes is straightforward. Every remote have a different way of
 
 - Access Key & Secret Key: [Understanding and getting your AWS credentials: programmatic access](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)
 - Region: the region is the region of your bucket.
+- Endpoint: (optional) the endpoint to use for the client, i.e. another s3 compatible service.
+- force_path_style: (optional) Forces this client to use path-style addressing for buckets, necessary for some s3 compatible gateways.
 
 ### SSH
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,7 +44,7 @@ pub struct AwsConfig {
     pub endpoint: Option<String>,
     pub access_key: String,
     pub secret_key: String,
-    pub force_path_style: Option<bool>
+    pub force_path_style: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,8 +41,10 @@ pub struct SshConfig {
 #[derive(Serialize, Deserialize)]
 pub struct AwsConfig {
     pub region: String,
+    pub endpoint: Option<String>,
     pub access_key: String,
     pub secret_key: String,
+    pub force_path_style: Option<bool>
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/remotes/aws.rs
+++ b/src/remotes/aws.rs
@@ -83,7 +83,8 @@ impl Bucket {
 impl AwsBucket {
     pub async fn new(config: AwsConfig, bucket_name: &str) -> Result<AwsBucket, Error> {
         let region = Region::new(config.region);
-        let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region);
+        let mut builder =
+            aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region);
         if let Some(endpoint) = &config.endpoint {
             builder = builder.endpoint_url(endpoint);
         }

--- a/src/remotes/aws.rs
+++ b/src/remotes/aws.rs
@@ -83,8 +83,11 @@ impl Bucket {
 impl AwsBucket {
     pub async fn new(config: AwsConfig, bucket_name: &str) -> Result<AwsBucket, Error> {
         let region = Region::new(config.region);
-        let config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .region(region)
+        let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest()).region(region);
+        if let Some(endpoint) = &config.endpoint {
+            builder = builder.endpoint_url(endpoint);
+        }
+        let sdk_config = builder
             .credentials_provider(SharedCredentialsProvider::new(
                 aws_credential_types::Credentials::from_keys(
                     config.access_key,
@@ -95,7 +98,9 @@ impl AwsBucket {
             .load()
             .await;
 
-        let client = Client::new(&config);
+        let mut conf_builder = aws_sdk_s3::config::Builder::from(&sdk_config);
+        conf_builder.set_force_path_style(config.force_path_style);
+        let client = Client::from_conf(conf_builder.build());
         let bucket = Bucket {
             client,
             bucket_name: bucket_name.to_owned(),


### PR DESCRIPTION
I would like to use this library with storj, this is the easiest way to allow compatibility. It would be posible to add the full SDK but it would be too much clutter as it is bindings over a go library.