### PR TITLE
Fix "TARmageddon" vulnerability CVE-2025-62518

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ aws-config = "1.6.3"
 aws-credential-types = { version = "1.2.3", features = ["hardcoded-credentials"] }
 aws-sdk-s3 = "1.91.0"
 async-compression = { version = "0.4.23", default-features = false, features = ["tokio", "gzip"] }
-tokio-tar = "0.3.1"
+astral-tokio-tar = "0.5.6"
 tokio-cron-scheduler = "0.14.0"
 cron = "0.15.0"
 uuid = { version = "1.17.0", features = ["v4"] }


### PR DESCRIPTION
switch to astral-tokio-tar which is maintained.